### PR TITLE
Add 'main' to package.json, to allow requiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/mattslocum/ng-webworker.git"
   },
+  "main": "src/ng-webworker.js",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Right now, it's impossible to load this module using webpack (or similar), because there is no entry point (['main'](https://docs.npmjs.com/files/package.json#main)) specified in the package.json.

This *should* fix #34 